### PR TITLE
Add OpenFisca

### DIFF
--- a/awesome-codegouvfr.yml
+++ b/awesome-codegouvfr.yml
@@ -98,6 +98,10 @@ https://github.com/GouvernementFR/dsfr:
   default_branch: main
   added: 2025-03-26
 
+https://github.com/openfisca/openfisca-core:
+  default_branch: master
+  added: 2025-07-17
+
 # https://github.com/suitenumerique/docs:
 #   added: 2025-03-19
 


### PR DESCRIPTION
- License: AGPL
- Proof of maintenance: see activity on GitHub and Slack
- Documentation: https://openfisca.org/doc/
- Proof of usage by French public administration: https://openfisca.org/fr/galerie/
- Proof of support by French public administration: Eure-et-Loir department is [member of the Association](https://openfisca.org/fr/association/); Parliament is [employing FTEs](https://leximpact.an.fr/recrutement) for OpenFisca development; DINUM supported OpenFisca at the Rules as Code EU conference. 